### PR TITLE
Make the MaxBlocksPerRequest configurable

### DIFF
--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -258,6 +258,8 @@ acryl {
 
     # Send transaction to peers on broadcast request even if it's already in utx-pool
     allow-tx-rebroadcasting = true
+
+    max-blocks-per-request = 100
   }
 
   # Nodes synchronization settings

--- a/node/src/main/scala/com/acrylplatform/api/http/BlocksApiRoute.scala
+++ b/node/src/main/scala/com/acrylplatform/api/http/BlocksApiRoute.scala
@@ -20,8 +20,7 @@ import play.api.libs.json._
 case class BlocksApiRoute(settings: RestAPISettings, blockchain: Blockchain, allChannels: ChannelGroup)(implicit sc: Scheduler)
     extends ApiRoute
     with WithSettings {
-  private[this] val MaxBlocksPerRequest = 100 // todo: make this configurable and fix integration tests
-  private[this] val commonApi           = new CommonBlocksApi(blockchain)
+  private[this] val commonApi = new CommonBlocksApi(blockchain)
 
   override lazy val route =
     pathPrefix("blocks") {
@@ -38,7 +37,7 @@ case class BlocksApiRoute(settings: RestAPISettings, blockchain: Blockchain, all
     ))
   def address: Route = (path("address" / Segment / IntNumber / IntNumber) & get) {
     case (address, start, end) =>
-      if (end >= 0 && start >= 0 && end - start >= 0 && end - start < MaxBlocksPerRequest) {
+      if (end >= 0 && start >= 0 && end - start >= 0 && end - start < settings.maxBlocksPerRequest) {
         val result = for {
           address <- Address.fromString(address)
           jsonBlocks = commonApi.blockHeadersRange(start, end).filter(_._1.signerData.generator.toAddress == address).map {
@@ -174,7 +173,7 @@ case class BlocksApiRoute(settings: RestAPISettings, blockchain: Blockchain, all
   }
 
   private def seq(start: Int, end: Int, includeTransactions: Boolean): StandardRoute = {
-    if (end >= 0 && start >= 0 && end - start >= 0 && end - start < MaxBlocksPerRequest) {
+    if (end >= 0 && start >= 0 && end - start >= 0 && end - start < settings.maxBlocksPerRequest) {
       val blocks = if (includeTransactions) {
         commonApi
           .blocksRange(start, end)

--- a/node/src/main/scala/com/acrylplatform/settings/RestAPISettings.scala
+++ b/node/src/main/scala/com/acrylplatform/settings/RestAPISettings.scala
@@ -8,4 +8,5 @@ case class RestAPISettings(enable: Boolean,
                            apiKeyDifferentHost: Boolean,
                            transactionsByAddressLimit: Int,
                            distributionAddressLimit: Int,
-                           allowTxRebroadcasting: Boolean)
+                           allowTxRebroadcasting: Boolean,
+                           maxBlocksPerRequest: Int)


### PR DESCRIPTION
This PR makes the MaxBlocksPerRequest parameter configurable by extracting its value to the configuration file - `applicaiton.conf`.

So now you can change the value of this particular parameter by editing the configuration file, for example.