### PR TITLE
Fixed IT test, added docker config, spelling and codestyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ sbt checkPR
 ```
 * if test failed, you should increase memory limits:
 ```
-SBT_OPTS="-Xms512M -Xmx15024M -Xss128M -XX:MaxMetaspaceSize=8192M" sbt checkPR
+SBT_OPTS="-Xms512M -Xmx8192M -Xss128M -XX:MaxMetaspaceSize=8192M" sbt checkPR
 ```
 
 ## 4. Running NODE integration tests (optional)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ cd Acryl
 ```
 sbt checkPR
 ```
+* if test failed, you should increase memory limits:
+```
+SBT_OPTS="-Xms512M -Xmx15024M -Xss128M -XX:MaxMetaspaceSize=8192M" sbt checkPR
+```
 
 ## 4. Running NODE integration tests (optional)
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ sbt checkPR
 
 Create a Docker image before you run any test: `sbt node-it/docker`
 
+- Retrieve the list of available tests: `sbt node-it/printTests`
 - Run all tests: `SBT_THREAD_NUMBER=4 sbt node-it/test` . You can increase or decrease number of parallel running tests by changing `SBT_THREAD_NUMBER`
 - Run one test: `sbt node-it/testOnly *.TestClassName` or `node-it/testOnly full.package.TestClassName`
 

--- a/node-it/build.sbt
+++ b/node-it/build.sbt
@@ -14,3 +14,13 @@ inTask(docker)(
       (Test / sourceDirectory).value / "container" / "start-acryl.sh"
     )
   ))
+
+lazy val printTests = taskKey[Unit]("Print all available Test's")
+
+printTests := {
+  val logger: Logger = ConsoleLogger()
+  val tests = (definedTests in Test).value
+  tests.zipWithIndex foreach { case (t, i) =>
+    logger.info(s"[$i] ${t.name}")
+  }
+}

--- a/node-it/build.sbt
+++ b/node-it/build.sbt
@@ -8,8 +8,9 @@ libraryDependencies ++= Dependencies.itTest
 inTask(docker)(
   Seq(
     imageNames := Seq(ImageName("com.acrylplatform/node-it")),
-    exposedPorts := Set(6863, 6869), // NetworkApi, RestApi
-    additionalFiles ++= (LocalProject("node") / Universal / stage).value +: Seq(
+    exposedPorts := Set(6870, 6869), // NetworkApi, RestApi
+    additionalFiles ++= Seq(
+      (LocalProject("node") / Universal / stage).value,
       (Test / resourceDirectory).value / "template.conf",
       (Test / sourceDirectory).value / "container" / "start-acryl.sh"
     )

--- a/node-it/src/test/resources/template.conf
+++ b/node-it/src/test/resources/template.conf
@@ -50,7 +50,9 @@ acryl {
       genesis {
         average-block-delay = 10s
         initial-base-target = 50000
-        initial-balance = 6400000000000000
+        block-timestamp     = 0
+        timestamp           = 0
+        initial-balance     = 6400000000000000
         transactions = [
           # Initial balances are balanced (pun intended) in such way that initial block
           # generation delay doesn't vary much, no matter which node is chosen as a miner.

--- a/node-it/src/test/scala/com/acrylplatform/it/Docker.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/Docker.scala
@@ -270,13 +270,14 @@ class Docker(suiteConfig: Config = empty, tag: String = "", enableProfiling: Boo
     }
 
   private def getNodeInfo(containerId: String, settings: AcrylSettings): NodeInfo = {
-    val restApiPort = settings.restAPISettings.port
-    val networkPort = settings.networkSettings.bindAddress.getPort
+    val restApiPort     = settings.restAPISettings.port
+    val networkPort     = settings.networkSettings.bindAddress.getPort
+    val dockerIpAddress = settings.networkSettings.dockerIpAddress
 
     val containerInfo  = inspectContainer(containerId)
     val acrylIpAddress = containerInfo.networkSettings().networks().get(acrylNetwork.name()).ipAddress()
 
-    NodeInfo(restApiPort, networkPort, acrylIpAddress, containerInfo.networkSettings().ports())
+    NodeInfo(restApiPort, networkPort, acrylIpAddress, containerInfo.networkSettings().ports(), dockerIpAddress)
   }
 
   private def inspectContainer(containerId: String): ContainerInfo = {
@@ -553,9 +554,9 @@ object Docker {
       .map { case (k, v) => s"-D$k=$v" }
       .mkString(" ")
 
-  case class NodeInfo(restApiPort: Int, networkPort: Int, acrylIpAddress: String, ports: JMap[String, JList[PortBinding]]) {
-    val nodeApiEndpoint: URL                       = new URL(s"http://localhost:${externalPort(restApiPort)}")
-    val hostNetworkAddress: InetSocketAddress      = new InetSocketAddress("localhost", externalPort(networkPort))
+  case class NodeInfo(restApiPort: Int, networkPort: Int, acrylIpAddress: String, ports: JMap[String, JList[PortBinding]], dockerIpAddress: String = "localhost") {
+    val nodeApiEndpoint: URL                       = new URL(s"http://$dockerIpAddress:${externalPort(restApiPort)}")
+    val hostNetworkAddress: InetSocketAddress      = new InetSocketAddress(dockerIpAddress, externalPort(networkPort))
     val containerNetworkAddress: InetSocketAddress = new InetSocketAddress(acrylIpAddress, networkPort)
 
     def externalPort(internalPort: Int): Int = ports.get(s"$internalPort/tcp").get(0).hostPort().toInt

--- a/node-it/src/test/scala/com/acrylplatform/it/Docker.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/Docker.scala
@@ -70,7 +70,7 @@ class Docker(suiteConfig: Config = empty, tag: String = "", enableProfiling: Boo
   private val genesisOverride = Docker.genesisOverride
 
   // a random network in 10.x.x.x range
-  val networkSeed = Random.nextInt(0x100000) << 4 | 0x0A000000
+  private val networkSeed = Random.nextInt(0x100000) << 4 | 0x0A000000
   // 10.x.x.x/28 network will accommodate up to 13 nodes
   private val networkPrefix = s"${InetAddress.getByAddress(toByteArray(networkSeed)).getHostAddress}/28"
 

--- a/node-it/src/test/scala/com/acrylplatform/it/ExternalNode.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/ExternalNode.scala
@@ -7,11 +7,11 @@ import com.typesafe.config.Config
 class ExternalNode(config: Config) extends Node(config) {
   override def nodeExternalPort(internalPort: Int): Int = internalPort
 
-  override def nodeApiEndpoint = new URL(config.getString("node-api-endpoint"))
+  override def nodeApiEndpoint: URL = new URL(config.getString("node-api-endpoint"))
 
-  override def apiKey = config.getString("api-key")
+  override def apiKey: String = config.getString("api-key")
 
-  override def networkAddress = {
+  override def networkAddress: InetSocketAddress = {
     val hostAndPort             = "([^:]+)\\:([\\d+])+".r
     val hostAndPort(host, port) = config.getString("network-address")
     new InetSocketAddress(host, port.toInt)

--- a/node-it/src/test/scala/com/acrylplatform/it/IntegrationSuiteWithThreeAddresses.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/IntegrationSuiteWithThreeAddresses.scala
@@ -48,7 +48,7 @@ trait IntegrationSuiteWithThreeAddresses
       })
     }
 
-    def waitForTxsToReachAllNodes(txIds: Seq[String]) = {
+    def waitForTxsToReachAllNodes(txIds: Seq[String]): Unit = {
       val txNodePairs = for {
         txId <- txIds
         node <- nodes

--- a/node-it/src/test/scala/com/acrylplatform/it/WaitForHeight2.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/WaitForHeight2.scala
@@ -14,7 +14,7 @@ trait WaitForHeight2 extends BeforeAndAfterAll with ScorexLogging with Reporting
 
   abstract protected override def beforeAll(): Unit = {
     super.beforeAll()
-    Await.result(traverse(nodes)(_.waitForHeight(2)), 1.minute)
+    Await.result(traverse(nodes)(_.waitForHeight(2)), 3.minute)
   }
 
   def waitForTxsToReachAllNodes(nodes: Seq[Node] = nodes, txIds: Seq[String]): Future[_] = {

--- a/node-it/src/test/scala/com/acrylplatform/it/api/model.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/api/model.scala
@@ -51,12 +51,14 @@ object DecompiledScript {
   implicit val decompiledScriptFormat: Format[DecompiledScript] = Json.format
 }
 
-case class FullAssetInfo(assetId: String,
-                         balance: Long,
-                         reissuable: Boolean,
-                         minSponsoredAssetFee: Option[Long],
-                         sponsorBalance: Option[Long],
-                         quantity: Long)
+case class FullAssetInfo(
+    assetId: String,
+    balance: Long,
+    reissuable: Boolean,
+    minSponsoredAssetFee: Option[Long],
+    sponsorBalance: Option[Long],
+    quantity: Long
+)
 object FullAssetInfo {
   implicit val fullAssetInfoFormat: Format[FullAssetInfo] = Json.format
 }
@@ -76,17 +78,19 @@ object ScriptAssetInfo {
   implicit val scriptAssetInfoFormat: Format[ScriptAssetInfo] = Json.format
 }
 
-case class AssetInfo(assetId: String,
-                     issueHeight: Int,
-                     issueTimestamp: Long,
-                     issuer: String,
-                     name: String,
-                     description: String,
-                     decimals: Int,
-                     reissuable: Boolean,
-                     quantity: Long,
-                     minSponsoredAssetFee: Option[Long],
-                     scriptDetails: Option[ScriptAssetInfo])
+case class AssetInfo(
+    assetId: String,
+    issueHeight: Int,
+    issueTimestamp: Long,
+    issuer: String,
+    name: String,
+    description: String,
+    decimals: Int,
+    reissuable: Boolean,
+    quantity: Long,
+    minSponsoredAssetFee: Option[Long],
+    scriptDetails: Option[ScriptAssetInfo]
+)
 object AssetInfo {
   implicit val AssetInfoFormat: Format[AssetInfo] = Json.format
 }
@@ -108,33 +112,37 @@ trait TxInfo {
   def script: Option[String]
 }
 
-case class TransactionInfo(`type`: Int,
-                           id: String,
-                           fee: Long,
-                           timestamp: Long,
-                           sender: Option[String],
-                           height: Int,
-                           minSponsoredAssetFee: Option[Long],
-                           recipient: Option[String],
-                           script: Option[String]) extends TxInfo
+case class TransactionInfo(
+    `type`: Int,
+    id: String,
+    fee: Long,
+    timestamp: Long,
+    sender: Option[String],
+    height: Int,
+    minSponsoredAssetFee: Option[Long],
+    recipient: Option[String],
+    script: Option[String]
+) extends TxInfo
 object TransactionInfo {
   implicit val format: Format[TransactionInfo] = Json.format
 }
 
-case class OrderInfo(id: String,
-                     version: Option[Byte],
-                     sender: String,
-                     senderPublicKey: String,
-                     matcherPublicKey: String,
-                     assetPair: AssetPairResponse,
-                     orderType: String,
-                     amount: Long,
-                     price: Long,
-                     timestamp: Long,
-                     expiration: Long,
-                     matcherFee: Long,
-                     signature: String,
-                     proofs: Option[Seq[String]])
+case class OrderInfo(
+    id: String,
+    version: Option[Byte],
+    sender: String,
+    senderPublicKey: String,
+    matcherPublicKey: String,
+    assetPair: AssetPairResponse,
+    orderType: String,
+    amount: Long,
+    price: Long,
+    timestamp: Long,
+    expiration: Long,
+    matcherFee: Long,
+    signature: String,
+    proofs: Option[Seq[String]]
+)
 object OrderInfo {
   implicit val transactionFormat: Format[OrderInfo] = Json.format
 }
@@ -144,24 +152,24 @@ object AssetPairResponse {
   implicit val pairResponseFormat: Format[AssetPairResponse] = Json.format
 }
 
-
-
 case class StateChangesDetails(data: Seq[DataResponse], transfers: Seq[TransfersInfoResponse])
 object StateChangesDetails {
   implicit val stateChangeResponseFormat: Format[StateChangesDetails] = Json.format[StateChangesDetails]
 }
 
-case class DebugStateChanges(`type`: Int,
-                             id: String,
-                             fee: Long,
-                             timestamp: Long,
-                             sender: Option[String],
-                             height: Int,
-                             minSponsoredAssetFee: Option[Long],
-                             recipient: Option[String],
-                             script: Option[String],
-                             stateChanges: Option[StateChangesDetails]) extends TxInfo
-object DebugStateChanges{
+case class DebugStateChanges(
+    `type`: Int,
+    id: String,
+    fee: Long,
+    timestamp: Long,
+    sender: Option[String],
+    height: Int,
+    minSponsoredAssetFee: Option[Long],
+    recipient: Option[String],
+    script: Option[String],
+    stateChanges: Option[StateChangesDetails]
+) extends TxInfo
+object DebugStateChanges {
   implicit val debugStateChanges: Format[DebugStateChanges] = Json.format
 }
 
@@ -181,44 +189,50 @@ object TransfersInfoResponse {
   implicit val transfersInfoResponseFormat: Format[TransfersInfoResponse] = Json.format
 }
 
-case class ExchangeTransaction(`type`: Int,
-                               version: Option[Byte],
-                               id: String,
-                               sender: String,
-                               senderPublicKey: String,
-                               fee: Long,
-                               timestamp: Long,
-                               proofs: Option[Seq[String]],
-                               order1: OrderInfo,
-                               order2: OrderInfo,
-                               amount: Long,
-                               price: Long,
-                               buyMatcherFee: Long,
-                               sellMatcherFee: Long,
-                               height: Option[Int])
+case class ExchangeTransaction(
+    `type`: Int,
+    version: Option[Byte],
+    id: String,
+    sender: String,
+    senderPublicKey: String,
+    fee: Long,
+    timestamp: Long,
+    proofs: Option[Seq[String]],
+    order1: OrderInfo,
+    order2: OrderInfo,
+    amount: Long,
+    price: Long,
+    buyMatcherFee: Long,
+    sellMatcherFee: Long,
+    height: Option[Int]
+)
 object ExchangeTransaction {
   implicit val transactionFormat: Format[ExchangeTransaction] = Json.format
 }
 
-case class Block(signature: String,
-                 height: Int,
-                 timestamp: Long,
-                 generator: String,
-                 transactions: Seq[Transaction],
-                 fee: Long,
-                 features: Option[Seq[Short]])
+case class Block(
+    signature: String,
+    height: Int,
+    timestamp: Long,
+    generator: String,
+    transactions: Seq[Transaction],
+    fee: Long,
+    features: Option[Seq[Short]]
+)
 object Block {
   implicit val blockFormat: Format[Block] = Json.format
 }
 
-case class BlockHeaders(signature: String,
-                        height: Int,
-                        timestamp: Long,
-                        generator: String,
-                        transactionCount: Int,
-                        blocksize: Int,
-                        features: Option[Set[Short]],
-                        totalFee: Long)
+case class BlockHeaders(
+    signature: String,
+    height: Int,
+    timestamp: Long,
+    generator: String,
+    transactionCount: Int,
+    blocksize: Int,
+    features: Option[Set[Short]],
+    totalFee: Long
+)
 object BlockHeaders {
   implicit val blockHeadersFormat: Format[BlockHeaders] = Json.format
 }
@@ -253,13 +267,15 @@ object AssetDecimalsInfo {
   implicit val assetDecimalsInfoResponseFormat: Format[AssetDecimalsInfo] = Json.format
 }
 
-case class MarketData(amountAsset: String,
-                      amountAssetName: String,
-                      priceAsset: String,
-                      priceAssetName: String,
-                      created: Long,
-                      amountAssetInfo: Option[AssetDecimalsInfo],
-                      priceAssetInfo: Option[AssetDecimalsInfo])
+case class MarketData(
+    amountAsset: String,
+    amountAssetName: String,
+    priceAsset: String,
+    priceAssetName: String,
+    created: Long,
+    amountAssetInfo: Option[AssetDecimalsInfo],
+    priceAssetInfo: Option[AssetDecimalsInfo]
+)
 object MarketData {
   implicit val marketData: Format[MarketData] = Json.format
 }
@@ -274,14 +290,16 @@ object MessageMatcherResponse {
   implicit val messageMatcherResponseFormat: Format[MessageMatcherResponse] = Json.format
 }
 
-case class OrderbookHistory(id: String,
-                            `type`: String,
-                            amount: Long,
-                            price: Long,
-                            timestamp: Long,
-                            filled: Int,
-                            status: String,
-                            assetPair: AssetPair) {
+case class OrderbookHistory(
+    id: String,
+    `type`: String,
+    amount: Long,
+    price: Long,
+    timestamp: Long,
+    filled: Int,
+    status: String,
+    assetPair: AssetPair
+) {
   def isActive: Boolean = status == "PartiallyFilled" || status == "Accepted"
 }
 object OrderbookHistory {
@@ -318,19 +336,16 @@ object OrderBookResponse {
   implicit val orderBookResponseFormat: Format[OrderBookResponse] = Json.format
 }
 
-case class MarketStatusResponse(lastPrice: Option[Long],
-                                lastSide: Option[String],
-                                bid: Option[Long],
-                                bidAmount: Option[Long],
-                                ask: Option[Long],
-                                askAmount: Option[Long])
+case class MarketStatusResponse(
+    lastPrice: Option[Long],
+    lastSide: Option[String],
+    bid: Option[Long],
+    bidAmount: Option[Long],
+    ask: Option[Long],
+    askAmount: Option[Long]
+)
 object MarketStatusResponse {
   implicit val marketResponseFormat: Format[MarketStatusResponse] = Json.format
-}
-
-case class DebugInfo(stateHeight: Long, stateHash: Long)
-object DebugInfo {
-  implicit val debugInfoFormat: Format[DebugInfo] = Json.format
 }
 
 case class BlacklistedPeer(hostname: String, timestamp: Long, reason: String)

--- a/node-it/src/test/scala/com/acrylplatform/it/async/WideStateGenerationSuite.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/async/WideStateGenerationSuite.scala
@@ -32,6 +32,7 @@ class WideStateGenerationSuite extends FreeSpec with WaitForHeight2 with Matcher
         |  synchronization.utx-synchronizer {
         |    max-buffer-size = 500
         |    max-buffer-time = 100ms
+        |    max-queue-size = 50000
         |  }
         |  utx.allow-skip-checks = false
         |  utx.max-scripted-size = 1000000

--- a/node-it/src/test/scala/com/acrylplatform/it/async/WideStateGenerationSuite.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/async/WideStateGenerationSuite.scala
@@ -57,15 +57,15 @@ class WideStateGenerationSuite extends FreeSpec with WaitForHeight2 with Matcher
         generateTransfersToRandomAddresses(requestsCount / 2, nodeAddresses) ++
           generateTransfersBetweenAccounts(requestsCount / 2, b))
 
-      _ <- Await.ready(traverse(nodes)(_.waitFor[Int]("UTX is empty")(_.utxSize, _ == 0, 5.seconds)), 7.minutes)
+      _ <- Await.ready(traverse(nodes)(_.waitFor[Int]("UTX is empty")(_.utxSize, _ == 0, 5.seconds)), 14.minutes)
 
       height <- traverse(nodes)(_.height).map(_.max)
-      _      <- Await.ready(nodes.waitForSameBlockHeadersAt(height + 1), 5.minutes)
+      _      <- Await.ready(nodes.waitForSameBlockHeadersAt(height + 1), 8.minutes)
 
-      _ <- Await.ready(traverse(nodes)(assertHasTxs(_, uploadedTxs.map(_.id).toSet)), 5.minutes)
+      _ <- Await.ready(traverse(nodes)(assertHasTxs(_, uploadedTxs.map(_.id).toSet)), 8.minutes)
     } yield ()
 
-    val limit = GlobalTimer.instance.schedule(Future.failed(new TimeoutException("Time is out for test")), 18.minutes)
+    val limit = GlobalTimer.instance.schedule(Future.failed(new TimeoutException("Time is out for test")), 22.minutes)
     val testWithDumps = Future.firstCompletedOf(Seq(test, limit)).recoverWith {
       case e =>
         for {
@@ -77,7 +77,7 @@ class WideStateGenerationSuite extends FreeSpec with WaitForHeight2 with Matcher
         }
     }
 
-    Await.result(testWithDumps, 18.minutes)
+    Await.result(testWithDumps, 22.minutes)
   }
 
   private def assertHasTxs(node: Node, txIds: Set[String]): Future[Unit] = {

--- a/node-it/src/test/scala/com/acrylplatform/it/async/WideStateGenerationSuite.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/async/WideStateGenerationSuite.scala
@@ -60,7 +60,7 @@ class WideStateGenerationSuite extends FreeSpec with WaitForHeight2 with Matcher
       _ <- Await.ready(traverse(nodes)(_.waitFor[Int]("UTX is empty")(_.utxSize, _ == 0, 5.seconds)), 7.minutes)
 
       height <- traverse(nodes)(_.height).map(_.max)
-      _      <- Await.ready(nodes.waitForSameBlockHeadesAt(height + 1), 5.minutes)
+      _      <- Await.ready(nodes.waitForSameBlockHeadersAt(height + 1), 5.minutes)
 
       _ <- Await.ready(traverse(nodes)(assertHasTxs(_, uploadedTxs.map(_.id).toSet)), 5.minutes)
     } yield ()

--- a/node-it/src/test/scala/com/acrylplatform/it/sync/BlacklistTestSuite.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/sync/BlacklistTestSuite.scala
@@ -39,7 +39,7 @@ class BlacklistTestSuite extends FreeSpec with Matchers with CancelAfterFailure 
 
   "and sync again" in {
     val baseHeight = nodes.map(_.height).max
-    nodes.waitForSameBlockHeadesAt(baseHeight + 5)
+    nodes.waitForSameBlockHeadersAt(baseHeight + 5)
   }
 
 }

--- a/node-it/src/test/scala/com/acrylplatform/it/sync/CustomFeeTransactionSuite.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/sync/CustomFeeTransactionSuite.scala
@@ -2,6 +2,7 @@ package com.acrylplatform.it.sync
 
 import com.typesafe.config.{Config, ConfigFactory}
 import com.acrylplatform.account.KeyPair
+import com.acrylplatform.common.state.ByteStr
 import com.acrylplatform.common.utils.EitherExt2
 import com.acrylplatform.it.NodeConfigs.Default
 import com.acrylplatform.it.api.SyncHttpApi._
@@ -50,7 +51,7 @@ class CustomFeeTransactionSuite extends BaseTransactionSuite with CancelAfterFai
     notMiner.assertAssetBalance(minerAddress, issuedAssetId, transferFee)
 
     // after `feature-check-blocks-period` asset fees should be sponsored
-    nodes.waitForSameBlockHeadesAt(featureCheckBlocksPeriod)
+    nodes.waitForSameBlockHeadersAt(featureCheckBlocksPeriod)
     val sponsoredId = notMiner.transfer(senderAddress, secondAddress, 1, transferFee, Some(issuedAssetId), Some(issuedAssetId)).id
     nodes.waitForHeightAriseAndTxPresent(sponsoredId)
 
@@ -69,12 +70,12 @@ class CustomFeeTransactionSuite extends BaseTransactionSuite with CancelAfterFai
 object CustomFeeTransactionSuite {
   private val minerAddress             = Default.head.getString("address")
   private val senderAddress            = Default(2).getString("address")
-  private val defaultAssetQuantity     = 999999999999l
+  private val defaultAssetQuantity     = 999999999999L
   private val featureCheckBlocksPeriod = 13
 
   private val seed = Default(2).getString("account-seed")
   private val pk   = KeyPair.fromSeed(seed).explicitGet()
-  val assetTx = IssueTransactionV1
+  val assetTx: IssueTransactionV1 = IssueTransactionV1
     .selfSigned(
       sender = pk,
       name = "asset".getBytes("UTF-8"),
@@ -88,7 +89,7 @@ object CustomFeeTransactionSuite {
     .right
     .get
 
-  val assetId = assetTx.id()
+  val assetId: ByteStr = assetTx.id()
 
   private val minerConfig = ConfigFactory.parseString(s"""
                                                          | acryl.fees.transfer.$assetId = 100000

--- a/node-it/src/test/scala/com/acrylplatform/it/sync/FairPoSTestSuite.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/sync/FairPoSTestSuite.scala
@@ -12,14 +12,14 @@ class FairPoSTestSuite extends FunSuite with CancelAfterFailure with NodesFromDo
   override protected def nodeConfigs: Seq[Config] = Configs
 
   test("blockchain grows with FairPoS activated") {
-    nodes.waitForSameBlockHeadesAt(height = 10, conditionAwaitTime = 11.minutes)
+    nodes.waitForSameBlockHeadersAt(height = 10, conditionAwaitTime = 11.minutes)
 
     val txId = nodes.head.transfer(nodes.head.address, nodes.last.address, transferAmount, minFee).id
     nodes.last.waitForTransaction(txId)
 
     val heightAfterTransfer = nodes.head.height
 
-    nodes.waitForSameBlockHeadesAt(heightAfterTransfer + 10, conditionAwaitTime = 11.minutes)
+    nodes.waitForSameBlockHeadersAt(heightAfterTransfer + 10, conditionAwaitTime = 11.minutes)
   }
 }
 

--- a/node-it/src/test/scala/com/acrylplatform/it/sync/NodeRestartTestSuite.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/sync/NodeRestartTestSuite.scala
@@ -20,7 +20,7 @@ class NodeRestartTestSuite extends FreeSpec with Matchers with WaitForHeight2 wi
   private def nodeB = nodes(1)
 
   "node should grow up to 5 blocks together and sync" in {
-    nodes.waitForSameBlockHeadesAt(height = 5)
+    nodes.waitForSameBlockHeadersAt(height = 5)
   }
 
   "create many addresses and check them after node restart" in {
@@ -29,7 +29,7 @@ class NodeRestartTestSuite extends FreeSpec with Matchers with WaitForHeight2 wi
     val nodeAWithOtherPorts = docker.restartContainer(dockerNodes().head)
     val maxHeight           = nodes.map(_.height).max
     nodeAWithOtherPorts.getAddresses should contain theSameElementsAs setOfAddresses
-    nodes.waitForSameBlockHeadesAt(maxHeight + 2)
+    nodes.waitForSameBlockHeadersAt(maxHeight + 2)
   }
 
   "after restarting all the nodes, the duplicate transaction cannot be put into the blockchain" in {

--- a/node-it/src/test/scala/com/acrylplatform/it/sync/block/BlockHeadersTestSuite.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/sync/block/BlockHeadersTestSuite.scala
@@ -53,7 +53,7 @@ class BlockHeadersTestSuite extends FunSuite with CancelAfterFailure with Transf
   test("blockSeq content should be equal to blockHeaderSeq, except transactions info") {
     val baseHeight = nodes.map(_.height).max
     Await.result(processRequests(generateTransfersToRandomAddresses(30, nodeAddresses)), 2.minutes)
-    nodes.waitForSameBlockHeadesAt(baseHeight + 3)
+    nodes.waitForSameBlockHeadersAt(baseHeight + 3)
     val blocks       = nodes.head.blockSeq(baseHeight + 1, baseHeight + 3)
     val blockHeaders = nodes.head.blockHeadersSeq(baseHeight + 1, baseHeight + 3)
 

--- a/node-it/src/test/scala/com/acrylplatform/it/sync/network/NetworkSeparationTestSuite.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/sync/network/NetworkSeparationTestSuite.scala
@@ -25,7 +25,7 @@ class NetworkSeparationTestSuite
   private def nodeB: Node = nodes.last
 
   "node should grow up to 10 blocks together and sync" in {
-    nodes.waitForSameBlockHeadesAt(10)
+    nodes.waitForSameBlockHeadersAt(10)
   }
 
   // Doing all work in one step, because nodes will not be available for requests and ReportingTestName fails here
@@ -40,7 +40,7 @@ class NetworkSeparationTestSuite
   "nodes should sync" in {
     val maxHeight = nodes.map(_.height).max
     log.debug(s"Max height is $maxHeight")
-    nodes.waitForSameBlockHeadesAt(maxHeight + 5)
+    nodes.waitForSameBlockHeadersAt(maxHeight + 5)
   }
 
   "after fork node should apply correct subchain" in {

--- a/node-it/src/test/scala/com/acrylplatform/it/sync/package.scala
+++ b/node-it/src/test/scala/com/acrylplatform/it/sync/package.scala
@@ -40,6 +40,7 @@ package object sync {
 
   val supportedVersions: List[Byte] = List(1, 2)
 
+  //noinspection ScalaDeprecation
   val script: Script       = ScriptCompiler(s"""true""".stripMargin, isAssetScript = false).explicitGet()._1
   val scriptBase64: String = script.bytes.value.base64
 

--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -54,6 +54,9 @@ acryl {
     # Node nonce to send during handshake. Should be different if few nodes runs on the same external IP address. Comment this out to set random nonce.
     # nonce = 0
 
+    # Docker machine host / IP address (used in the integration tests)
+    docker-ip-address = "localhost"
+
     # List of IP addresses of well known nodes.
     known-peers = ["188.166.74.161:6870", "159.203.115.46:6870", "206.189.155.110:6870", "134.209.201.198:6870"]
 

--- a/node/src/main/scala/com/acrylplatform/api/http/PeersApiRoute.scala
+++ b/node/src/main/scala/com/acrylplatform/api/http/PeersApiRoute.scala
@@ -93,16 +93,16 @@ case class PeersApiRoute(settings: RestAPISettings,
     json[ConnectReq] { req =>
       val add: InetSocketAddress = new InetSocketAddress(InetAddress.getByName(req.host), req.port)
       val channel: Channel = connectToPeer(add)
-      val chanelIsCreated: Boolean = channel != null && channel.isInstanceOf[Channel]
+      val channelIsCreated: Boolean = channel != null && channel.isInstanceOf[Channel]
 
       Json.obj(
         "hostname" -> add.getHostName,
         "status"     -> "Trying to connect",
-        "open"       -> (if (chanelIsCreated) channel.isOpen else false),
-        "active"     -> (if (chanelIsCreated) channel.isActive else false),
-        "registered" -> (if (chanelIsCreated) channel.isRegistered else false),
-        "writable"   -> (if (chanelIsCreated) channel.isWritable else false),
-        "id"         -> (if (chanelIsCreated) id(channel) else "")
+        "open"       -> (if (channelIsCreated) channel.isOpen else false),
+        "active"     -> (if (channelIsCreated) channel.isActive else false),
+        "registered" -> (if (channelIsCreated) channel.isRegistered else false),
+        "writable"   -> (if (channelIsCreated) channel.isWritable else false),
+        "id"         -> (if (channelIsCreated) id(channel) else "")
       )
     }
   }

--- a/node/src/main/scala/com/acrylplatform/api/http/PeersApiRoute.scala
+++ b/node/src/main/scala/com/acrylplatform/api/http/PeersApiRoute.scala
@@ -17,7 +17,7 @@ import scala.collection.JavaConverters._
 @Path("/peers")
 @Api(value = "/peers", description = "Get info about peers", position = 2)
 case class PeersApiRoute(settings: RestAPISettings,
-                         connectToPeer: InetSocketAddress => Unit,
+                         connectToPeer: InetSocketAddress => Channel,
                          peerDatabase: PeerDatabase,
                          establishedConnections: ConcurrentMap[Channel, PeerInfo])
     extends ApiRoute
@@ -25,7 +25,7 @@ case class PeersApiRoute(settings: RestAPISettings,
 
   import PeersApiRoute._
 
-  override lazy val route =
+  override lazy val route: Route =
     pathPrefix("peers") {
       allPeers ~ connectedPeers ~ blacklistedPeers ~ suspendedPeers ~ connect ~ clearBlacklist
     }
@@ -92,9 +92,17 @@ case class PeersApiRoute(settings: RestAPISettings,
   def connect: Route = (path("connect") & post & withAuth) {
     json[ConnectReq] { req =>
       val add: InetSocketAddress = new InetSocketAddress(InetAddress.getByName(req.host), req.port)
-      connectToPeer(add)
+      val channel: Channel = connectToPeer(add)
 
-      Json.obj("hostname" -> add.getHostName, "status" -> "Trying to connect")
+      Json.obj(
+        "hostname" -> add.getHostName,
+        "status"     -> "Trying to connect",
+        "open"       -> channel.isOpen.toString,
+        "active"     -> channel.isActive.toString,
+        "registered" -> channel.isRegistered.toString,
+        "writable"   -> channel.isWritable.toString,
+        "id"         -> id(channel)
+      )
     }
   }
 

--- a/node/src/main/scala/com/acrylplatform/api/http/PeersApiRoute.scala
+++ b/node/src/main/scala/com/acrylplatform/api/http/PeersApiRoute.scala
@@ -93,15 +93,16 @@ case class PeersApiRoute(settings: RestAPISettings,
     json[ConnectReq] { req =>
       val add: InetSocketAddress = new InetSocketAddress(InetAddress.getByName(req.host), req.port)
       val channel: Channel = connectToPeer(add)
+      val chanelIsCreated: Boolean = channel != null && channel.isInstanceOf[Channel]
 
       Json.obj(
         "hostname" -> add.getHostName,
         "status"     -> "Trying to connect",
-        "open"       -> channel.isOpen.toString,
-        "active"     -> channel.isActive.toString,
-        "registered" -> channel.isRegistered.toString,
-        "writable"   -> channel.isWritable.toString,
-        "id"         -> id(channel)
+        "open"       -> (if (chanelIsCreated) channel.isOpen else false),
+        "active"     -> (if (chanelIsCreated) channel.isActive else false),
+        "registered" -> (if (chanelIsCreated) channel.isRegistered else false),
+        "writable"   -> (if (chanelIsCreated) channel.isWritable else false),
+        "id"         -> (if (chanelIsCreated) id(channel) else "")
       )
     }
   }

--- a/node/src/main/scala/com/acrylplatform/network/HandshakeHandler.scala
+++ b/node/src/main/scala/com/acrylplatform/network/HandshakeHandler.scala
@@ -132,7 +132,7 @@ abstract class HandshakeHandler(localHandshake: Handshake,
 
 object HandshakeHandler extends ScorexLogging {
 
-  val NodeNameAttributeKey: AttributeKey[String] = AttributeKey.newInstance[String]("name")
+  val NodeNameAttributeKey: AttributeKey[String]      = AttributeKey.newInstance[String]("name")
 
   def versionIsSupported(remoteVersion: (Int, Int, Int)): Boolean =
     (remoteVersion._1 == 0 && remoteVersion._2 >= 13) || (remoteVersion._1 == 1 && remoteVersion._2 >= 0)
@@ -143,7 +143,7 @@ object HandshakeHandler extends ScorexLogging {
     val chainId = remote.substring(5)
     val localChainId = local.substring(5)
 
-    (appName == "waves" || appName == "acryl") && (chainId == "A" || chainId == "K") && chainId == localChainId
+    (appName == "waves" || appName == "acryl") && (chainId == "A" || chainId == "K" || chainId == "I") && chainId == localChainId
   }
 
   def removeHandshakeHandlers(ctx: ChannelHandlerContext, thisHandler: ChannelHandler): Unit = {

--- a/node/src/main/scala/com/acrylplatform/network/NetworkServer.scala
+++ b/node/src/main/scala/com/acrylplatform/network/NetworkServer.scala
@@ -27,7 +27,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
 trait NS {
-  def connect(remoteAddress: InetSocketAddress): Unit
+  def connect(remoteAddress: InetSocketAddress): Channel
 
   def shutdown(): Unit
 
@@ -191,7 +191,7 @@ object NetworkServer extends ScorexLogging {
       }
     }
 
-    def doConnect(remoteAddress: InetSocketAddress): Unit =
+    def doConnect(remoteAddress: InetSocketAddress): Channel =
       outgoingChannels.computeIfAbsent(
         remoteAddress,
         _ => {
@@ -245,7 +245,7 @@ object NetworkServer extends ScorexLogging {
       }
 
     new NS {
-      override def connect(remoteAddress: InetSocketAddress): Unit = doConnect(remoteAddress)
+      override def connect(remoteAddress: InetSocketAddress): Channel = doConnect(remoteAddress)
 
       override def shutdown(): Unit = doShutdown()
 

--- a/node/src/main/scala/com/acrylplatform/network/NetworkServer.scala
+++ b/node/src/main/scala/com/acrylplatform/network/NetworkServer.scala
@@ -88,7 +88,7 @@ object NetworkServer extends ScorexLogging {
     val inboundConnectionFilter: PipelineInitializer.HandlerWrapper =
       new InboundConnectionFilter(peerDatabase, settings.networkSettings.maxInboundConnections, settings.networkSettings.maxConnectionsPerHost)
 
-    val (mesageObserver, newtworkMessages)            = MessageObserver()
+    val (messageObserver, networkMessages)            = MessageObserver()
     val (channelClosedHandler, closedChannelsSubject) = ChannelClosedHandler()
     val discardingHandler                             = new DiscardingHandler(lastBlockInfos.map(_.ready))
     val peerConnections                               = new ConcurrentHashMap[PeerKey, Channel](10, 0.9f, 10)
@@ -121,7 +121,7 @@ object NetworkServer extends ScorexLogging {
           writeErrorHandler,
           peerSynchronizer,
           historyReplier,
-          mesageObserver,
+          messageObserver,
           fatalErrorHandler
         )))
         .bind(settings.networkSettings.bindAddress)
@@ -152,7 +152,7 @@ object NetworkServer extends ScorexLogging {
         writeErrorHandler,
         peerSynchronizer,
         historyReplier,
-        mesageObserver,
+        messageObserver,
         fatalErrorHandler
       )))
 
@@ -240,7 +240,7 @@ object NetworkServer extends ScorexLogging {
       } finally {
         workerGroup.shutdownGracefully().await()
         bossGroup.shutdownGracefully().await()
-        mesageObserver.shutdown()
+        messageObserver.shutdown()
         channelClosedHandler.shutdown()
       }
 
@@ -249,7 +249,7 @@ object NetworkServer extends ScorexLogging {
 
       override def shutdown(): Unit = doShutdown()
 
-      override val messages: Messages = newtworkMessages
+      override val messages: Messages = networkMessages
 
       override val closedChannels: Observable[Channel] = closedChannelsSubject
     }

--- a/node/src/main/scala/com/acrylplatform/network/PeerDatabaseImpl.scala
+++ b/node/src/main/scala/com/acrylplatform/network/PeerDatabaseImpl.scala
@@ -31,13 +31,13 @@ class PeerDatabaseImpl(settings: NetworkSettings) extends PeerDatabase with Scor
   private val reasons          = mutable.Map.empty[InetAddress, String]
   private val unverifiedPeers  = EvictingQueue.create[InetSocketAddress](settings.maxUnverifiedPeers)
 
-  for (a <- settings.knownPeers.view.map(inetSocketAddress(_, 6863))) {
+  for (a <- settings.knownPeers.view.map(inetSocketAddress(_, 6870))) {
     // add peers from config with max timestamp so they never get evicted from the list of known peers
     doTouch(a, Long.MaxValue)
   }
 
   for (f <- settings.file if f.exists()) try {
-    JsonFileStorage.load[PeersPersistenceType](f.getCanonicalPath).foreach(a => touch(inetSocketAddress(a, 6863)))
+    JsonFileStorage.load[PeersPersistenceType](f.getCanonicalPath).foreach(a => touch(inetSocketAddress(a, 6870)))
     log.info(s"Loaded ${peersPersistence.size} known peer(s) from ${f.getName}")
   } catch {
     case NonFatal(_) => log.info("Legacy or corrupted peers.dat, ignoring, starting all over from known-peers...")

--- a/node/src/main/scala/com/acrylplatform/settings/NetworkSettings.scala
+++ b/node/src/main/scala/com/acrylplatform/settings/NetworkSettings.scala
@@ -63,11 +63,7 @@ object NetworkSettings {
       new InetSocketAddress(uri.getHost, uri.getPort)
     }
 
-    // docker may have not bind on a localhost
-    val dockerIpAddress              = if (config.hasPath("docker-ip-address"))
-      config.as[String]("docker-ip-address")
-    else "localhost"
-
+    val dockerIpAddress              = config.as[String]("docker-ip-address")
     val knownPeers                   = config.as[Seq[String]]("known-peers")
     val peersDataResidenceTime       = config.as[FiniteDuration]("peers-data-residence-time")
     val blackListResidenceTime       = config.as[FiniteDuration]("black-list-residence-time")

--- a/node/src/main/scala/com/acrylplatform/settings/NetworkSettings.scala
+++ b/node/src/main/scala/com/acrylplatform/settings/NetworkSettings.scala
@@ -18,6 +18,7 @@ case class UPnPSettings(enable: Boolean, gatewayTimeout: FiniteDuration, discove
 case class NetworkSettings(file: Option[File],
                            bindAddress: InetSocketAddress,
                            declaredAddress: Option[InetSocketAddress],
+                           dockerIpAddress: String,
                            nodeName: String,
                            nonce: Long,
                            knownPeers: Seq[String],
@@ -62,6 +63,11 @@ object NetworkSettings {
       new InetSocketAddress(uri.getHost, uri.getPort)
     }
 
+    // docker may have not bind on a localhost
+    val dockerIpAddress              = if (config.hasPath("docker-ip-address"))
+      config.as[String]("docker-ip-address")
+    else "localhost"
+
     val knownPeers                   = config.as[Seq[String]]("known-peers")
     val peersDataResidenceTime       = config.as[FiniteDuration]("peers-data-residence-time")
     val blackListResidenceTime       = config.as[FiniteDuration]("black-list-residence-time")
@@ -84,6 +90,7 @@ object NetworkSettings {
       file,
       bindAddress,
       declaredAddress,
+      dockerIpAddress,
       nodeName,
       nonce,
       knownPeers,

--- a/node/src/test/scala/com/acrylplatform/http/PeersRouteSpec.scala
+++ b/node/src/test/scala/com/acrylplatform/http/PeersRouteSpec.scala
@@ -18,7 +18,7 @@ class PeersRouteSpec extends RouteSpec("/peers") with RestAPISettingsHelper with
   import PeersRouteSpec._
 
   private val peerDatabase   = mock[PeerDatabase]
-  private val connectToPeer  = mockFunction[InetSocketAddress, Unit]
+  private val connectToPeer  = mockFunction[InetSocketAddress, Channel]
   private val inetAddressGen = Gen.listOfN(4, Arbitrary.arbitrary[Byte]).map(_.toArray).map(InetAddress.getByAddress)
   private val inetSocketAddressGen = for {
     address <- inetAddressGen
@@ -110,7 +110,15 @@ object PeersRouteSpec {
 
   implicit val connectReqFormat: Format[ConnectReq] = Json.format
 
-  case class ConnectResp(status: String, hostname: String)
+  case class ConnectResp(
+    status: String,
+    hostname: String,
+    open: Boolean,
+    active: Boolean,
+    registered: Boolean,
+    writable: Boolean,
+    id: String
+  )
 
   implicit val connectRespFormat: Format[ConnectResp] = Json.format
 

--- a/node/src/test/scala/com/acrylplatform/network/peer/PeerDatabaseImplSpecification.scala
+++ b/node/src/test/scala/com/acrylplatform/network/peer/PeerDatabaseImplSpecification.scala
@@ -104,7 +104,7 @@ class PeerDatabaseImplSpecification extends path.FreeSpecLike with Matchers {
     }
 
     "filters out wildcard addresses" in {
-      database.addCandidate(new InetSocketAddress("0.0.0.0", 6863))
+      database.addCandidate(new InetSocketAddress("0.0.0.0", 6870))
       database.randomPeer(Set(address1, address2)) shouldBe None
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,6 @@ object Dependencies {
 
   def akkaModule(module: String): ModuleID = "com.typesafe.akka" %% s"akka-$module" % "2.5.20"
 
-  private def swaggerModule(module: String)                = "io.swagger.core.v3"            % s"swagger-$module" % "2.0.5"
   private def akkaHttpModule(module: String)               = "com.typesafe.akka"             %% module            % "10.1.8"
   private def nettyModule(module: String)                  = "io.netty"                      % s"netty-$module"   % "4.1.33.Final"
   private def kamonModule(module: String, v: String)       = "io.kamon"                      %% s"kamon-$module"  % v
@@ -73,7 +72,7 @@ object Dependencies {
       shapeless.value
     ))
 
-  val console = Seq("com.github.scopt" %% "scopt" % "4.0.0-RC2")
+  val console: Seq[ModuleID] = Seq("com.github.scopt" %% "scopt" % "4.0.0-RC2")
 
   val common = Def.setting(
     Seq(
@@ -107,7 +106,8 @@ object Dependencies {
       compilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0-M4")
     ))
 
-  lazy val itTest = scalaTest +: Seq(
+  lazy val itTest: Seq[ModuleID] = scalaTest +: Seq(
+    logback,
     // Swagger is using Jersey 1.1, hence the shading (https://github.com/spotify/docker-client#a-note-on-shading)
     ("com.spotify" % "docker-client" % "8.15.1").classifier("shaded"),
     jacksonModule("dataformat", "dataformat-properties"),
@@ -115,7 +115,7 @@ object Dependencies {
     "org.scalacheck"      %% "scalacheck"       % "1.14.0"
   ).map(_ % Test)
 
-  lazy val test = scalaTest +: Seq(
+  lazy val test: Seq[ModuleID] = scalaTest +: Seq(
     logback.exclude("org.scala-js", "scalajs-library_2.12"),
     "org.scalacheck" %% "scalacheck" % "1.14.0",
     ("io.github.amrhassan" %% "scalacheck-cats" % "0.4.0").exclude("org.scalacheck", "scalacheck_2.12"),
@@ -156,7 +156,7 @@ object Dependencies {
     ) ++ protobuf.value ++ test ++ console
   )
 
-  lazy val matcher = Seq(
+  lazy val matcher: Seq[ModuleID] = Seq(
     akkaModule("actor"),
     akkaModule("persistence-query"),
     akkaHttp,


### PR DESCRIPTION
- codestyle
- spelling
- changed docker port "expose" for network (6863 -> 6870)
- added possibility for change dockerIpAddress (remove "localhost" hardcode)
- removed unused dependency
- changed default port in the Peers Database class (6863 -> 6870)
- added connection information to the "connect" API method
- fixed WideStateGenerationSuite it test (increase await time and max-queue-size)
- added mode-it/printTests command, for dumping test classes name
- added chainId = I to check application name (according to settings)
- fixed connect method test
- update readme

corrections after discussion - https://github.com/acrylplatform/Acryl/pull/8.